### PR TITLE
fix #44 "Get only first container and cause smartide start failed"

### DIFF
--- a/cli/cmd/start/env.go
+++ b/cli/cmd/start/env.go
@@ -138,9 +138,7 @@ func convertOriginContainer(containers []types.Container,
 				Ports:         ports,
 			}
 			dockerComposeContainers = append(dockerComposeContainers, dockerComposeContainer)
-			break
 		}
-
 	}
 
 	return dockerComposeContainers


### PR DESCRIPTION
fix #44

This bug will make gin-vue-admin demo failed with "ERROR  从services [gva-vscode-dev gva-goland-dev gva-mysql phpmyadmin gva-redis] 中获取 开发容器名称失败".

